### PR TITLE
Make prefix optional

### DIFF
--- a/custom_components/s3_compatible/config_flow.py
+++ b/custom_components/s3_compatible/config_flow.py
@@ -36,7 +36,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
             config=TextSelectorConfig(type=TextSelectorType.PASSWORD)
         ),
         vol.Required(CONF_BUCKET): cv.string,
-        vol.Required(CONF_PREFIX, default=""): cv.string,
+        vol.Optional(CONF_PREFIX, default=""): cv.string,
         vol.Required(CONF_ENDPOINT_URL, default=DEFAULT_ENDPOINT_URL): TextSelector(
             config=TextSelectorConfig(type=TextSelectorType.URL)
         ),


### PR DESCRIPTION
Make the config flow accept a empty prefix. This is needed if you want to use a bucket directly, without a prefix. 