### PR TITLE
refactor: create s3 client in backup agent

### DIFF
--- a/custom_components/s3_compatible/__init__.py
+++ b/custom_components/s3_compatible/__init__.py
@@ -6,8 +6,7 @@ import logging
 from typing import cast
 
 from aiobotocore.client import AioBaseClient as S3Client
-from aiobotocore.session import AioSession
-from botocore.config import Config
+from aiobotocore.session import get_session
 from botocore.exceptions import ClientError, ConnectionError, ParamValidationError
 
 from homeassistant.config_entries import ConfigEntry
@@ -18,7 +17,6 @@ from .const import (
     BOTO_CONFIG,
     CONF_ACCESS_KEY_ID,
     CONF_BUCKET,
-    CONF_PREFIX,
     CONF_ENDPOINT_URL,
     CONF_SECRET_ACCESS_KEY,
     DATA_BACKUP_AGENT_LISTENERS,
@@ -34,18 +32,16 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass: HomeAssistant, entry: S3ConfigEntry) -> bool:
     """Set up S3 from a config entry."""
 
-    data = cast(dict, entry.data)
+    data = cast("dict", entry.data)
     try:
-        session = AioSession()
-        # pylint: disable-next=unnecessary-dunder-call
-        client = await session.create_client(
+        async with get_session().create_client(
             "s3",
             endpoint_url=data.get(CONF_ENDPOINT_URL),
             aws_secret_access_key=data[CONF_SECRET_ACCESS_KEY],
             aws_access_key_id=data[CONF_ACCESS_KEY_ID],
             config=BOTO_CONFIG,
-        ).__aenter__()
-        await client.head_bucket(Bucket=data[CONF_BUCKET])
+        ) as client:
+            await client.head_bucket(Bucket=data[CONF_BUCKET])
     except ClientError as err:
         raise ConfigEntryError(
             translation_domain=DOMAIN,
@@ -68,8 +64,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: S3ConfigEntry) -> bool:
             translation_key="cannot_connect",
         ) from err
 
-    entry.runtime_data = client
-
     def notify_backup_listeners() -> None:
         for listener in hass.data.get(DATA_BACKUP_AGENT_LISTENERS, []):
             listener()
@@ -81,6 +75,4 @@ async def async_setup_entry(hass: HomeAssistant, entry: S3ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: S3ConfigEntry) -> bool:
     """Unload a config entry."""
-    client = entry.runtime_data
-    await client.__aexit__(None, None, None)
     return True

--- a/custom_components/s3_compatible/config_flow.py
+++ b/custom_components/s3_compatible/config_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from aiobotocore.session import AioSession
+from aiobotocore.session import get_session
 from botocore.exceptions import ClientError, ConnectionError, ParamValidationError
 import voluptuous as vol
 
@@ -62,8 +62,7 @@ class S3ConfigFlow(ConfigFlow, domain=DOMAIN):
             )
 
             try:
-                session = AioSession()
-                async with session.create_client(
+                async with get_session().create_client(
                     "s3",
                     endpoint_url=user_input.get(CONF_ENDPOINT_URL),
                     aws_secret_access_key=user_input[CONF_SECRET_ACCESS_KEY],


### PR DESCRIPTION
This PR replaces the (possibly) long-living s3 client in the `runtime_data` of the HA config entry.
Instead an [`S3Client`](https://youtype.github.io/types_aiobotocore_docs/types_aiobotocore_s3/client/) instance is created whenever necessary, with the credentials persisted on the `AioSession` inside `S3BackupAgent`.

Hopefully helps with #12, however it doesn't quite make sense to me why boto would keep trying to load its service definitions while a backup is running if the client instance still exists. Does HA perhaps reload the config (aka call [`async_setup_entry`](https://github.com/PhantomPhoton/S3-Compatible/blob/4ffff3ca39e6959f1baaed2e72850e584cf72de1/custom_components/s3_compatible/__init__.py#L34)), causing it to be replaced?

Is `async_unload_entry` still required if it only returns `True`? I'm not familiar enough with HA internals to tell.

I've only tested the config flow and backup to MinIO, however no business logic *should* be affected as this only changes where the s3 client is created.