### PR TITLE
added Regions to support Garage S3

### DIFF
--- a/custom_components/s3_compatible/__init__.py
+++ b/custom_components/s3_compatible/__init__.py
@@ -18,6 +18,7 @@ from .const import (
     CONF_ACCESS_KEY_ID,
     CONF_BUCKET,
     CONF_ENDPOINT_URL,
+    CONF_REGION,
     CONF_SECRET_ACCESS_KEY,
     DATA_BACKUP_AGENT_LISTENERS,
     DOMAIN,
@@ -37,6 +38,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: S3ConfigEntry) -> bool:
         async with get_session().create_client(
             "s3",
             endpoint_url=data.get(CONF_ENDPOINT_URL),
+            region_name=data.get(CONF_REGION),
             aws_secret_access_key=data[CONF_SECRET_ACCESS_KEY],
             aws_access_key_id=data[CONF_ACCESS_KEY_ID],
             config=BOTO_CONFIG,

--- a/custom_components/s3_compatible/backup.py
+++ b/custom_components/s3_compatible/backup.py
@@ -23,6 +23,7 @@ from .const import (
     BOTO_CONFIG,
     CONF_BUCKET,
     CONF_PREFIX,
+    CONF_REGION,
     DATA_BACKUP_AGENT_LISTENERS,
     DOMAIN,
     CONF_ACCESS_KEY_ID,
@@ -113,6 +114,7 @@ class S3BackupAgent(BackupAgent):
             secret_key=entry.data[CONF_SECRET_ACCESS_KEY],
         )
         self._endpoint_url = entry.data.get(CONF_ENDPOINT_URL)
+        self._region = entry.data.get(CONF_REGION)
 
         self._bucket: str = entry.data[CONF_BUCKET]
         self._prefix: str = entry.data.get(CONF_PREFIX, "")
@@ -126,6 +128,7 @@ class S3BackupAgent(BackupAgent):
         return self._session.create_client(
             "s3",
             endpoint_url=self._endpoint_url,
+            region_name=self._region,
             config=BOTO_CONFIG,
         )
 

--- a/custom_components/s3_compatible/config_flow.py
+++ b/custom_components/s3_compatible/config_flow.py
@@ -23,7 +23,9 @@ from .const import (
     CONF_ENDPOINT_URL,
     CONF_SECRET_ACCESS_KEY,
     CONF_PREFIX,
+    CONF_REGION,
     DEFAULT_ENDPOINT_URL,
+    DEFAULT_REGION,
     DESCRIPTION_AWS_S3_DOCS_URL,
     DESCRIPTION_BOTO3_DOCS_URL,
     DOMAIN,
@@ -36,6 +38,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
             config=TextSelectorConfig(type=TextSelectorType.PASSWORD)
         ),
         vol.Required(CONF_BUCKET): cv.string,
+        vol.Required(CONF_REGION, default=DEFAULT_REGION): cv.string,
         vol.Optional(CONF_PREFIX, default=""): cv.string,
         vol.Required(CONF_ENDPOINT_URL, default=DEFAULT_ENDPOINT_URL): TextSelector(
             config=TextSelectorConfig(type=TextSelectorType.URL)
@@ -65,6 +68,7 @@ class S3ConfigFlow(ConfigFlow, domain=DOMAIN):
                 async with get_session().create_client(
                     "s3",
                     endpoint_url=user_input.get(CONF_ENDPOINT_URL),
+                    region_name=user_input.get(CONF_REGION),
                     aws_secret_access_key=user_input[CONF_SECRET_ACCESS_KEY],
                     aws_access_key_id=user_input[CONF_ACCESS_KEY_ID],
                     config=BOTO_CONFIG,

--- a/custom_components/s3_compatible/const.py
+++ b/custom_components/s3_compatible/const.py
@@ -13,9 +13,11 @@ CONF_SECRET_ACCESS_KEY = "secret_access_key"
 CONF_ENDPOINT_URL = "endpoint_url"
 CONF_BUCKET = "bucket"
 CONF_PREFIX = "prefix"
+CONF_REGION = "region"
 
 AWS_DOMAIN = "amazonaws.com"
-DEFAULT_ENDPOINT_URL = f"https://s3.eu-central-1.{AWS_DOMAIN}/"
+DEFAULT_REGION = "us-east-1"
+DEFAULT_ENDPOINT_URL = f"https://s3.{DEFAULT_REGION}.{AWS_DOMAIN}/"
 
 DATA_BACKUP_AGENT_LISTENERS: HassKey[list[Callable[[], None]]] = HassKey(
     f"{DOMAIN}.backup_agent_listeners"

--- a/custom_components/s3_compatible/strings.json
+++ b/custom_components/s3_compatible/strings.json
@@ -6,6 +6,7 @@
           "access_key_id": "Access key ID",
           "secret_access_key": "Secret access key",
           "bucket": "Bucket name",
+          "region": "Region",
           "endpoint_url": "Endpoint URL",
           "prefix": "Prefix"
         },


### PR DESCRIPTION
This pull request adds support for specifying the AWS S3 region in the S3-compatible integration. The region can now be configured through the UI, is used when creating S3 clients, and has a sensible default. This improves compatibility with different S3 endpoints and regions.

**Configuration and Constants:**

* Added `CONF_REGION` and `DEFAULT_REGION` constants to `const.py`, and updated the default endpoint URL to use the default region.
* Updated `strings.json` to include the "region" field for localization.

**User Interface and Config Flow:**

* Modified `config_flow.py` to require the region in the configuration form, using `DEFAULT_REGION` as the default value. [[1]](diffhunk://#diff-d49509a48bbc7cc867bac1bd703e58cec1ad719f46c9dbb484ef5b4f06b6aaf4R26-R28) [[2]](diffhunk://#diff-d49509a48bbc7cc867bac1bd703e58cec1ad719f46c9dbb484ef5b4f06b6aaf4R41)

**S3 Client Initialization:**

* Updated all S3 client creation points in `__init__.py`, `backup.py`, and `config_flow.py` to pass the `region_name` parameter using the configured region. [[1]](diffhunk://#diff-bd80a5c8228813376fb36d0936cea3f87aece8754aa1b88e89cdff69d43044d0R21) [[2]](diffhunk://#diff-bd80a5c8228813376fb36d0936cea3f87aece8754aa1b88e89cdff69d43044d0R41) [[3]](diffhunk://#diff-138794d1b61bdc85600ea7b9f04b4f54a0d2f2c2d54e9641fdd8e2f23d71b308R26) [[4]](diffhunk://#diff-138794d1b61bdc85600ea7b9f04b4f54a0d2f2c2d54e9641fdd8e2f23d71b308R117) [[5]](diffhunk://#diff-138794d1b61bdc85600ea7b9f04b4f54a0d2f2c2d54e9641fdd8e2f23d71b308R131) [[6]](diffhunk://#diff-d49509a48bbc7cc867bac1bd703e58cec1ad719f46c9dbb484ef5b4f06b6aaf4R71)