### PR TITLE
Bump aiobotocore to 3.4.0 to fix botocore version mismatch

### DIFF
--- a/custom_components/s3_compatible/manifest.json
+++ b/custom_components/s3_compatible/manifest.json
@@ -12,7 +12,7 @@
   "loggers": ["aiobotocore"],
   "quality_scale": "bronze",
   "requirements": [
-    "aiobotocore==2.21.1"
+    "aiobotocore==3.4.0"
   ],
   "version": "1.0.6"
 }


### PR DESCRIPTION
HA bumped its bundled botocore to 1.42.79+ which added `s3_disable_express_session_auth` as a required argument, breaking client creation with aiobotocore 2.21.1. Bumping to 3.4.0 (targets botocore 1.42.79–1.42.84) fixes it.

fixes #23