### PR TITLE
Fix: relax aiobotocore version constraint to prevent ImportError on newer botocore

### DIFF
--- a/custom_components/s3_compatible/manifest.json
+++ b/custom_components/s3_compatible/manifest.json
@@ -12,7 +12,7 @@
   "loggers": ["aiobotocore"],
   "quality_scale": "bronze",
   "requirements": [
-    "aiobotocore==3.4.0"
+    "aiobotocore>=3.4.2"
   ],
   "version": "1.0.6"
 }


### PR DESCRIPTION
## Problem

On recent Home Assistant versions (tested on 2026.5.4 / HAOS 17.3), the
integration fails to load with:

> Config flow could not be loaded: {"message":"Invalid handler specified"}

The underlying error in the logs is:

```
Error occurred loading flow for integration s3_compatible: cannot import name
'register_feature_id' from 'botocore.useragent'
```


This happens because `aiobotocore==3.4.0` calls `register_feature_id` from
`botocore.useragent`, which was removed in a newer botocore release. Since HA
manages its own dependency resolution, it can pull in a botocore version that
is incompatible with the hard-pinned aiobotocore.

## Fix

Relax the requirement from `aiobotocore==3.4.0` to `aiobotocore>=3.4.2`,
allowing HA to install a version of aiobotocore that is compatible with
whatever botocore is present. The latest release is currently 3.7.0.

## Testing

Verified the integration loads and backup targets can be added successfully
after this change on HA Core 2026.5.4.