### PR TITLE
Allow editing of entity settings

### DIFF
--- a/custom_components/s3_compatible/config_flow.py
+++ b/custom_components/s3_compatible/config_flow.py
@@ -27,8 +27,6 @@ from .const import (
     CONF_VERIFY,
     DEFAULT_ENDPOINT_URL,
     DEFAULT_REGION,
-    DESCRIPTION_AWS_S3_DOCS_URL,
-    DESCRIPTION_BOTO3_DOCS_URL,
     DOMAIN,
 )
 
@@ -56,54 +54,107 @@ class S3ConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a flow initiated by the user."""
+        return await self._async_step_setup("user", user_input)
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Allow reconfiguration of an existing config entry."""
+        return await self._async_step_setup("reconfigure", user_input)
+
+    async def _async_step_setup(
+        self,
+        step_id: str,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Handle user setup and reconfiguration."""
+        reconfigure = step_id == "reconfigure"
+        entry = self._get_reconfigure_entry() if reconfigure else None
         errors: dict[str, str] = {}
-        description_placeholders = {
-             "aws_s3_docs_url": DESCRIPTION_AWS_S3_DOCS_URL,
-             "boto3_docs_url": DESCRIPTION_BOTO3_DOCS_URL,
-         }
+        description_placeholders: dict[str, str] = {}
 
         if user_input is not None:
-            self._async_abort_entries_match(
-                 {
-                    CONF_BUCKET: user_input[CONF_BUCKET],
-                    CONF_ENDPOINT_URL: user_input[CONF_ENDPOINT_URL],
-                 }
-             )
+            if self._is_duplicate(
+                user_input,
+                exclude_entry_id=entry.entry_id if entry else None,
+            ):
+                return self.async_abort(reason="already_configured")
 
-            try:
-                async with create_client(
-                     "s3",
-                    endpoint_url=user_input.get(CONF_ENDPOINT_URL),
-                    region_name=user_input.get(CONF_REGION),
-                    aws_secret_access_key=user_input[CONF_SECRET_ACCESS_KEY],
-                    aws_access_key_id=user_input[CONF_ACCESS_KEY_ID],
-                    verify=user_input.get(CONF_VERIFY, None) if user_input.get(CONF_VERIFY, None) != "" else None,
-                 ) as client:
-                    await client.head_bucket(Bucket=user_input[CONF_BUCKET])
-            except ClientError:
-                errors["base"] = "invalid_credentials"
-            except ParamValidationError as err:
-                if "Invalid bucket name" in str(err):
-                    errors[CONF_BUCKET] = "invalid_bucket_name"
-                elif "region" in str(err).lower():
-                    errors["base"] = "wrong_region"
-                    match = re.search(r"region '([^']+)'", str(err))
-                    if match:
-                        description_placeholders["region"] = match.group(1)
-            except ValueError:
-                errors[CONF_ENDPOINT_URL] = "invalid_endpoint_url"
-            except ConnectionError:
-                errors[CONF_ENDPOINT_URL] = "cannot_connect"
-            else:
+            errors, description_placeholders = await self._async_validate_connection(
+                user_input
+            )
+
+            if not errors:
+                if reconfigure:
+                    return self.async_update_reload_and_abort(
+                        entry,
+                        data_updates=user_input,
+                        title=user_input[CONF_BUCKET],
+                    )
                 return self.async_create_entry(
                     title=user_input[CONF_BUCKET], data=user_input
-                 )
+                )
 
+        defaults = dict(entry.data) if entry else user_input
         return self.async_show_form(
-            step_id="user",
+            step_id=step_id,
             data_schema=self.add_suggested_values_to_schema(
-                STEP_USER_DATA_SCHEMA, user_input
-             ),
+                STEP_USER_DATA_SCHEMA, defaults
+            ),
             errors=errors,
             description_placeholders=description_placeholders,
-         )
+        )
+
+    def _is_duplicate(
+        self,
+        user_input: dict[str, Any],
+        *,
+        exclude_entry_id: str | None = None,
+    ) -> bool:
+        """Return True if another entry uses the same bucket and endpoint."""
+        for existing in self._async_current_entries(include_ignore=False):
+            if exclude_entry_id and existing.entry_id == exclude_entry_id:
+                continue
+            if (
+                existing.data.get(CONF_BUCKET) == user_input[CONF_BUCKET]
+                and existing.data.get(CONF_ENDPOINT_URL)
+                == user_input[CONF_ENDPOINT_URL]
+            ):
+                return True
+        return False
+
+    async def _async_validate_connection(
+        self,
+        user_input: dict[str, Any],
+    ) -> tuple[dict[str, str], dict[str, str]]:
+        """Validate credentials and bucket access."""
+        errors: dict[str, str] = {}
+        description_placeholders: dict[str, str] = {}
+        try:
+            async with create_client(
+                "s3",
+                endpoint_url=user_input.get(CONF_ENDPOINT_URL),
+                region_name=user_input.get(CONF_REGION),
+                aws_secret_access_key=user_input[CONF_SECRET_ACCESS_KEY],
+                aws_access_key_id=user_input[CONF_ACCESS_KEY_ID],
+                verify=user_input.get(CONF_VERIFY, None)
+                if user_input.get(CONF_VERIFY, None) != ""
+                else None,
+            ) as client:
+                await client.head_bucket(Bucket=user_input[CONF_BUCKET])
+        except ClientError:
+            errors["base"] = "invalid_credentials"
+        except ParamValidationError as err:
+            if "Invalid bucket name" in str(err):
+                errors[CONF_BUCKET] = "invalid_bucket_name"
+            elif "region" in str(err).lower():
+                errors["base"] = "wrong_region"
+                match = re.search(r"region '([^']+)'", str(err))
+                if match:
+                    description_placeholders["region"] = match.group(1)
+        except ValueError:
+            errors[CONF_ENDPOINT_URL] = "invalid_endpoint_url"
+        except ConnectionError:
+            errors[CONF_ENDPOINT_URL] = "cannot_connect"
+
+        return errors, description_placeholders

--- a/custom_components/s3_compatible/const.py
+++ b/custom_components/s3_compatible/const.py
@@ -23,6 +23,3 @@ DEFAULT_ENDPOINT_URL = f"https://s3.{DEFAULT_REGION}.{AWS_DOMAIN}/"
 DATA_BACKUP_AGENT_LISTENERS: HassKey[list[Callable[[], None]]] = HassKey(
     f"{DOMAIN}.backup_agent_listeners"
 )
-
-DESCRIPTION_AWS_S3_DOCS_URL = "https://docs.aws.amazon.com/general/latest/gr/s3.html"
-DESCRIPTION_BOTO3_DOCS_URL = "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html"

--- a/custom_components/s3_compatible/manifest.json
+++ b/custom_components/s3_compatible/manifest.json
@@ -12,5 +12,5 @@
   "loggers":  ["custom_components.s3_compatible"],
   "quality_scale": "bronze",
   "requirements": ["requests-aws4auth>=1.2"],
-  "version": "2.0.0"
+  "version": "2.1.0"
 }

--- a/custom_components/s3_compatible/translations/en.json
+++ b/custom_components/s3_compatible/translations/en.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "already_configured": "Account is already configured"
+      "already_configured": "Account is already configured",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "error": {
       "cannot_connect": "Cannot connect to endpoint",
@@ -24,13 +25,34 @@
         "data_description": {
           "access_key_id": "Access key ID to connect to AWS S3 API",
           "bucket": "Bucket must already exist and be writable by the provided credentials.",
-          "endpoint_url": "Endpoint URL provided to [Boto3 Session]({boto3_docs_url}). Region-specific [AWS S3 endpoints]({aws_s3_docs_url}) are available in their docs.",
+          "endpoint_url": "Endpoint URL for the S3-compatible service.",
           "secret_access_key": "Secret access key to connect to AWS S3 API",
           "region": "For most self-hosted solutions, this can be set to anything you want and is unused",
           "prefix": "Prefix to be added to every key. This can be used to emulate a directory layout with 'foo/'",
           "verify": "This is only used if you are using a custom CA for the S3 host. Most people will want to leave this blank"
         },
         "title": "Add AWS S3 bucket"
+      },
+      "reconfigure": {
+        "data": {
+          "access_key_id": "Access key ID",
+          "bucket": "Bucket name",
+          "endpoint_url": "Endpoint URL",
+          "secret_access_key": "Secret access key",
+          "region": "Region",
+          "prefix": "Prefix",
+          "verify": "Path to a pem file"
+        },
+        "data_description": {
+          "access_key_id": "Access key ID to connect to AWS S3 API",
+          "bucket": "Bucket must already exist and be writable by the provided credentials.",
+          "endpoint_url": "Endpoint URL for the S3-compatible service.",
+          "secret_access_key": "Secret access key to connect to AWS S3 API",
+          "region": "For most self-hosted solutions, this can be set to anything you want and is unused",
+          "prefix": "Prefix to be added to every key. This can be used to emulate a directory layout with 'foo/'",
+          "verify": "This is only used if you are using a custom CA for the S3 host. Most people will want to leave this blank"
+        },
+        "title": "Reconfigure S3 bucket"
       }
     }
   },


### PR DESCRIPTION
Due to the new s3 client, previously working setups may need their region reconfigured. This allows users to edit the region and other settings of their existing entities without needing to delete and re-add them.

Fixes #31