### PR TITLE
Fix backup download: add iter_chunks() to _Body

### DIFF
--- a/custom_components/s3_compatible/s3rest.py
+++ b/custom_components/s3_compatible/s3rest.py
@@ -335,6 +335,18 @@ class _Body:
         self._pos += len(chunk)
         return chunk
 
+    def iter_chunks(self, chunk_size: int | None = None) -> "_Body":
+        """Return an async iterator over the body in chunks.
+
+        Mirrors aiobotocore/boto3 StreamingBody.iter_chunks, which Home
+        Assistant's backup download handler calls
+        (agent.async_download_backup -> Body.iter_chunks()). _Body is already
+        an async iterator, so return self.
+        """
+        if chunk_size:
+            self._chunk_size = chunk_size
+        return self
+
     async def read(self) -> bytes:
         """Read the entire body as bytes."""
         return self._content


### PR DESCRIPTION
## Problem

Downloading/restoring a backup from the agent fails with HTTP 500:

```
File ".../custom_components/s3_compatible/backup.py", line 151, in async_download_backup
    return response["Body"].iter_chunks()
AttributeError: '_Body' object has no attribute 'iter_chunks'
```

`async_download_backup` calls `response["Body"].iter_chunks()`, but the `_Body`
wrapper in `s3rest.py` only implements `__aiter__` / `__anext__` / `read` — there
is no `iter_chunks()`. So every restore/download through Home Assistant's backup
download handler (`homeassistant/components/backup/http.py` →
`agent.async_download_backup`) raises `AttributeError`. Uploads are unaffected
(they use `open_stream`), so backups are created fine but can never be downloaded
or restored from the agent.

## Fix

Add `iter_chunks()` to `_Body`. `_Body` is already an async iterator, so it simply
returns `self` (optionally accepting a `chunk_size`, mirroring
aiobotocore/boto3 `StreamingBody.iter_chunks`).

## Testing

- HA Core 2026.7.4, backend = Ceph RGW (path-style, plain HTTP).
- Before: `GET /api/backup/download/<id>?agent_id=s3_compatible.<entry>` → HTTP 500
  with the traceback above.
- After: same request → HTTP 200, streams the full backup tar; `tar -tf` lists
  `homeassistant.tar.gz` / `ssl.tar.gz` / `backup.json`; HA restore-from-agent works.